### PR TITLE
Add files via upload

### DIFF
--- a/Twitter_file_splitting_PowerShell.txt
+++ b/Twitter_file_splitting_PowerShell.txt
@@ -1,0 +1,24 @@
+$PSDefaultParameterValues = @{'*:Encoding' = 'utf8'}
+
+$InputFilename = Get-Content 'input_file_name.json'
+
+$OutputFilenamePattern = 'output_file_name_part_'
+$LineLimit = 800000
+$line = 0
+$i = 0
+$file = 0
+$start = 0
+
+while ($line -le $InputFilename.Length) {
+if ($i -eq $LineLimit -Or $line -eq $InputFilename.Length) {
+$file++
+$Filename = "$OutputFilenamePattern$file.json"
+$InputFilename[$start..($line-1)] | Out-File $Filename -Force
+$start = $line;
+$i = 0
+Write-Host "$Filename"
+}
+$i++;
+$line++
+}
+$


### PR DESCRIPTION
This text file contains code used in Windows PowerShell to split large files by number of lines. In this case 800'000 lines (800'000 tweets) per file. The "$" at the beginning of every line and at the very end of the code is used to run the whole code in one go instead of line by line. This is very useful when working with large files, as some of the lines will take up much more time to run than others.